### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 MCP (Model Context Protocol) server to manage documents and perform searches using [Needle](https://needle-ai.com) through Claude’s Desktop Application.
 
+<a href="https://glama.ai/mcp/servers/5jw1t7hur2">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/5jw1t7hur2/badge" alt="Needle Server MCP server" />
+</a>
+
 ## Table of Contents
 
 - [Overview](#overview)


### PR DESCRIPTION
This PR adds a badge for the [Needle MCP Server](https://glama.ai/mcp/servers/5jw1t7hur2) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/5jw1t7hur2">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/5jw1t7hur2/badge" alt="Needle Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.